### PR TITLE
fix(auth): compare the password against the stored hash, not a startup copy

### DIFF
--- a/backend-go/internal/auth/auth.go
+++ b/backend-go/internal/auth/auth.go
@@ -316,9 +316,34 @@ func (s *Service) verifyPassword(username, password string) error {
 	if subtle.ConstantTimeCompare([]byte(username), []byte(s.cfg.AdminUsername)) != 1 {
 		return errors.New("unknown user")
 	}
-	// Primary: bcrypt hash stored in DB (set at startup or after password change).
-	if s.cfg.AdminPasswordHash != "" {
-		if bcrypt.CompareHashAndPassword([]byte(s.cfg.AdminPasswordHash), []byte(password)) == nil {
+
+	// The hash is read from the database on every attempt, not from a copy taken
+	// at startup.
+	//
+	// cfg.AdminPasswordHash is filled once in main() and never refreshed, while
+	// ChangePassword writes the new hash to the users table. Comparing against
+	// the copy meant a rotation was recorded, acknowledged with "Password
+	// changed successfully", and had no effect until the container restarted:
+	// the old password kept working and the new one was refused (#230). A
+	// credential rotation that reports success without taking effect is worse
+	// than one that fails, because the operator believes the old password is
+	// retired.
+	//
+	// The users table is already the source of truth: ChangePassword reads it to
+	// check the current password before writing the new one. One indexed lookup
+	// on a single-row table, on a path that is rate limited and already followed
+	// by bcrypt, is not a cost worth caching around.
+	hash, err := s.currentPasswordHash(username)
+	if err != nil {
+		// Refusing here rather than falling back to the startup copy: a database
+		// that cannot be read is not a reason to accept a password that may have
+		// been rotated out. Everything else in the API needs the database too,
+		// and /api/ready reports unready for the same condition.
+		log.Error().Err(err).Msg("cannot read stored password hash; refusing authentication")
+		return errors.New("password store unavailable")
+	}
+	if hash != "" {
+		if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil {
 			return nil
 		}
 		return errors.New("password mismatch")
@@ -329,6 +354,27 @@ func (s *Service) verifyPassword(username, password string) error {
 		return nil
 	}
 	return errors.New("password mismatch")
+}
+
+// currentPasswordHash returns the bcrypt hash stored for a user, or an empty
+// string when the row exists without one and on first boot before the seed has
+// run. An unreadable database is an error rather than an empty result, so the
+// caller can tell "no password set yet" from "cannot tell".
+func (s *Service) currentPasswordHash(username string) (string, error) {
+	if s.db == nil {
+		return s.cfg.AdminPasswordHash, nil
+	}
+	var stored string
+	switch err := s.db.QueryRow(
+		"SELECT password FROM users WHERE username = ?", username,
+	).Scan(&stored); {
+	case err == nil:
+		return stored, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return "", nil
+	default:
+		return "", err
+	}
 }
 
 func (s *Service) checkRateLimit(r *http.Request) error {

--- a/backend-go/internal/handlers/change_password_test.go
+++ b/backend-go/internal/handlers/change_password_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A changed password has to be the one that works, and the old one has to stop.
+//
+// #230: the settings page reported "Password changed successfully", the new
+// password was refused and the old one kept working. ChangePassword writes the
+// new bcrypt hash to the users table, but authentication compared against
+// cfg.AdminPasswordHash, a copy read from the database once during startup and
+// never refreshed. So the rotation was recorded, acknowledged, and had no
+// effect until the container was restarted.
+//
+// A credential rotation that reports success without taking effect is worse
+// than one that fails: the operator believes the old password is retired.
+func TestChangedPasswordIsTheOneThatWorks(t *testing.T) {
+	db, svc, cfg, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	const (
+		oldPassword = "admin-12345"
+		newPassword = "Str0nger-pass!"
+	)
+
+	h := NewAuthHandlers(db, svc, cfg, nil, nil)
+
+	body, _ := json.Marshal(map[string]string{
+		"current_password": oldPassword,
+		"new_password":     newPassword,
+	})
+	req := withUserContext(
+		httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewReader(body)),
+		"admin",
+	)
+	rec := httptest.NewRecorder()
+	h.ChangePassword(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("change-password returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	authenticate := func(password string) bool {
+		r := httptest.NewRequest(http.MethodGet, "/api/anything", nil)
+		r.SetBasicAuth("admin", password)
+		_, ok, _ := svc.Authenticate(r)
+		return ok
+	}
+
+	if !authenticate(newPassword) {
+		t.Error("the new password is refused: the change was reported as successful " +
+			"and did not take effect")
+	}
+	if authenticate(oldPassword) {
+		t.Error("the old password still works: it was not retired by the change")
+	}
+}
+
+// A password store that cannot be read refuses authentication rather than
+// falling back to the copy taken at startup. That copy may hold a password the
+// operator has already rotated out, and accepting it because the database is
+// briefly unavailable would undo the rotation exactly when nobody is watching.
+// Every other endpoint needs the database too, and /api/ready reports unready
+// for the same condition.
+func TestAuthenticationIsRefusedWhenTheHashCannotBeRead(t *testing.T) {
+	db, svc, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	r := httptest.NewRequest(http.MethodGet, "/api/anything", nil)
+	r.SetBasicAuth("admin", "admin-12345")
+	if _, ok, _ := svc.Authenticate(r); !ok {
+		t.Fatal("the correct password should authenticate before the table is dropped")
+	}
+
+	if _, err := db.Exec("DROP TABLE users"); err != nil {
+		t.Fatalf("could not drop users: %v", err)
+	}
+
+	r2 := httptest.NewRequest(http.MethodGet, "/api/anything", nil)
+	r2.SetBasicAuth("admin", "admin-12345")
+	if _, ok, _ := svc.Authenticate(r2); ok {
+		t.Error("authentication succeeded against a password store that cannot be read")
+	}
+}
+
+// First boot, before the seed has written a hash: the environment password is
+// still accepted. This is the path that lets an operator in on a fresh install.
+func TestEnvironmentPasswordStillWorksBeforeTheHashIsSeeded(t *testing.T) {
+	db, svc, cfg, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	if _, err := db.Exec("UPDATE users SET password='' WHERE username='admin'"); err != nil {
+		t.Fatalf("could not clear the hash: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/anything", nil)
+	r.SetBasicAuth("admin", cfg.AdminPassword)
+	if _, ok, _ := svc.Authenticate(r); !ok {
+		t.Error("the environment password is refused with no hash stored yet")
+	}
+}


### PR DESCRIPTION
Fixes #230, reported by @shyjuk.

## The report

> Tried changing password from settings. It shows password updated, but it seems it is not updated as new password is not working and I could login with old one.

Reproduced exactly, as a test:

```
--- FAIL: TestChangedPasswordIsTheOneThatWorks
    the new password is refused: the change was reported as successful and did not take effect
    the old password still works: it was not retired by the change
```

## Where it goes wrong

`ChangePassword` is correct. It checks the current password against the `users` table and writes the new bcrypt hash back to it:

```go
if _, err := h.db.Exec("UPDATE users SET password=? WHERE username=?", newHash, username); err != nil {
```

The other side is the problem. `main()` reads that hash once at boot:

```go
// Load bcrypt hash from DB so auth uses it instead of plaintext env-var.
var dbHash string
if err := db.QueryRow("SELECT password FROM users WHERE username = ?", cfg.AdminUsername).Scan(&dbHash); err == nil && dbHash != "" {
    cfg.AdminPasswordHash = dbHash
}
```

and `verifyPassword` compared against that copy, which nothing refreshes:

```go
// Primary: bcrypt hash stored in DB (set at startup or after password change).
if s.cfg.AdminPasswordHash != "" {
```

The comment describes the intent rather than the behaviour. Nothing sets it after a password change, so the rotation was written to the database, acknowledged in the UI, and had no effect until the container restarted.

A credential rotation that reports success without taking effect is worse than one that fails, because the operator believes the old password is retired and stops treating it as live.

## The fix

`verifyPassword` reads the hash from the `users` table on each attempt. That table is already the source of truth: `ChangePassword` reads it to verify the current password before writing the new one. One indexed lookup on a single-row table, on a path that is rate limited and already followed by bcrypt, is not a cost worth caching around.

One behaviour change worth calling out: **a database that cannot be read is now a refusal rather than a fallback to the startup copy.** That copy may hold a password the operator has already rotated out, and accepting it because SQLite is briefly unavailable would undo the rotation exactly when nobody is watching. Every other endpoint needs the database too, and `/api/ready` already reports unready for the same condition.

A row that exists with no hash is a different case from a row that cannot be read. The first is first boot before the seed, and still falls back to the environment password, which is what lets an operator in on a fresh install.

## Tests

`backend-go/internal/handlers/change_password_test.go`:

| test | what it pins |
|---|---|
| `TestChangedPasswordIsTheOneThatWorks` | the reported behaviour: new password works, old one stops |
| `TestAuthenticationIsRefusedWhenTheHashCannotBeRead` | no fallback to the startup copy when the store is unreadable |
| `TestEnvironmentPasswordStillWorksBeforeTheHashIsSeeded` | first boot is not broken by the change |

The first fails on the previous code, on both of its assertions.

## Not affected

Inter-service auth. `WAF_SERVICE_USERNAME`/`WAF_SERVICE_PASSWORD` are credentials this backend sends outward in `analytics.go`, validated by the WAF service against its own configuration. They never reach `verifyPassword`.

`go vet` is clean and the full `backend-go` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)