### PR TITLE
fix(ui): reference the direct dependency in the postcss override

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
     "vitest": "^4.1.2"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "$postcss",
     "follow-redirects": "^1.16.0",
     "browserslist": "^4.28.7",
     "nanoid": "^3.3.18"


### PR DESCRIPTION
Unblocks Dependabot on the `ui-dependencies` group. One line in `ui/package.json`.

## What is broken

Every attempt Dependabot makes at the UI group fails:

```
npm error code EOVERRIDE
npm error Override for postcss@8.5.28 conflicts with direct dependency
```

`postcss` is declared twice in `ui/package.json`, as a direct devDependency and as an override, both at `^8.5.10`:

```json
"devDependencies": { "postcss": "^8.5.10", ... },
"overrides":       { "postcss": "^8.5.10", "follow-redirects": "^1.16.0" }
```

npm requires an override on a package that is also a direct dependency to match that dependency's spec exactly. Dependabot changes the devDependency and leaves the override alone, the two diverge, and npm refuses to install.

Because `postcss` belongs to the `ui-dependencies` group, this blocks **the whole group**, not just postcss. That is why #245 has been stale since 31 August and is red on `UI TypeScript build`, `Docker build (all images)` and both E2E jobs.

This predates the audit work in #251: the same group update already failed on 6 September.

## The fix

npm has a form for exactly this case, and it is what the override was trying to say:

```json
"overrides": { "postcss": "$postcss", ... }
```

`$postcss` means "whatever the direct dependency resolves to". Transitive copies stay pinned to the direct one, and by construction nothing can diverge from it.

## Reproduced, then verified

Raising the devDependency to `^8.5.28` while the override read `^8.5.10`:

```
npm error code EOVERRIDE
npm error Override for postcss@^8.5.28 conflicts with direct dependency
```

The same change with the override reading `$postcss`:

```
esito npm: 0
postcss risolto: ['8.5.28']
copie di postcss nell'albero: 1
```

Installs cleanly, resolves to the requested version, and leaves exactly one copy in the tree, so the deduplication the override exists for is intact.

## The other overrides are fine

| override | also a direct dependency? |
|---|---|
| `postcss` | **yes** |
| `follow-redirects` | no |
| `browserslist` | no |
| `nanoid` | no |

Only `postcss` can hit this. The three transitive-only overrides are unaffected.

## Scope

The lockfile does not change: `$postcss` resolves to the same `^8.5.10` the devDependency already declares. `ui/package.json` is the whole diff, one line.

Audit gate clean, `npm run build` succeeds, 137 unit tests pass.

Once this is in, #245 can be recreated and reviewed on its merits instead of failing before it starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)