### PR TITLE
build(deps): keep majors out of the grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,18 @@
 version: 2
+
+# Grouped updates cover minor and patch only. A major lands as its own pull
+# request instead of riding along with twenty compatible bumps.
+#
+# The ui-dependencies group showed why. With `patterns: ["*"]` and no split it
+# collected typescript 5.9 -> 7.0, tailwindcss 3.4 -> 4.3, jsdom 29 -> 30 and
+# @types/node 24 -> 26 into one pull request, which failed the TypeScript build,
+# the Docker build and both E2E jobs. Nothing in it could be merged, so the
+# harmless minors behind it were stuck too, from 31 August until this was found.
+#
+# The split applies to npm and gomod, where a major changes source-level
+# compatibility (a Go major changes the import path outright). Docker and
+# github-actions stay grouped: a major there is a tag change that CI validates
+# end to end, and splitting it would only add noise.
 updates:
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -8,6 +22,9 @@ updates:
       ui-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gomod"
     directory: "/backend-go"
@@ -17,6 +34,9 @@ updates:
       backend-go-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gomod"
     directory: "/waf-go"
@@ -26,6 +46,9 @@ updates:
       waf-go-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -86,6 +109,9 @@ updates:
       docs-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Keep the SHA-pinned GitHub Actions (ci.yml, multi-arch.yml, docs.yml)
   # patched — pinning to a digest means we don't get upstream fixes otherwise.


### PR DESCRIPTION
Makes the `ui-dependencies` group mergeable again. Follows #252, which fixed a different cause of the same symptom.

## Why the group is red

`patterns: ["*"]` with no split means a major bump rides along with every compatible one. #245, and its recreated replacement #253, collect four majors into a single pull request:

```
typescript    ~5.9.3  ->  ~7.0.2
tailwindcss   ^3.4.1  ->  ^4.3.3
jsdom         ^29.0.1 ->  ^30.0.1
@types/node   ^24.12  ->  ^26.4.1
```

which is red on `UI TypeScript build`, `Docker build (all images)`, `E2E (compose up + smoke)` and `E2E UI (Playwright)`.

Nothing in that pull request can be merged, and the harmless minors behind it are stuck with it. It has been that way since 31 August. Tailwind 4 alone needs a configuration migration, so no amount of rebasing was going to turn it green.

## The change

Groups now cover `minor` and `patch`. A major arrives as its own pull request and is reviewed on its own terms.

| ecosystem | directory | group | update-types |
|---|---|---|---|
| npm | `/ui` | ui-dependencies | minor, patch |
| npm | `/docs` | docs-dependencies | minor, patch |
| gomod | `/backend-go` | backend-go-dependencies | minor, patch |
| gomod | `/waf-go` | waf-go-dependencies | minor, patch |
| docker | `/` | docker-dependencies | unchanged |
| github-actions | `/` | actions-dependencies | unchanged |

The split applies to npm and gomod, where a major changes source-level compatibility: a Go major changes the import path outright, and an npm major changes APIs and configuration. Docker and github-actions stay grouped, because a major there is a tag change that CI validates end to end, and splitting it would add noise without adding safety.

## Relationship to #252

Different cause, same symptom. #252 fixed the `postcss` override conflicting with the direct dependency, which meant Dependabot could not even recreate the group (`EOVERRIDE`). That unblocked the machinery. This makes what the machinery produces mergeable.

Once this is in, #253 can be closed and left to regenerate: the minors will come through on their own, and the four majors will arrive one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)