### PR TITLE
Make the merge gate real, and keep it in the repo

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,73 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {
+        "context": "UI TypeScript build"
+      },
+      {
+        "context": "Version sync"
+      },
+      {
+        "context": "Go backend build"
+      },
+      {
+        "context": "Go WAF build"
+      },
+      {
+        "context": "Backend unit tests"
+      },
+      {
+        "context": "WAF unit tests"
+      },
+      {
+        "context": "Go lint (golangci-lint) (backend-go)"
+      },
+      {
+        "context": "Go lint (golangci-lint) (waf-go)"
+      },
+      {
+        "context": "Shell lint (shellcheck)"
+      },
+      {
+        "context": "Squid config generation"
+      },
+      {
+        "context": "Security scanning"
+      },
+      {
+        "context": "Trivy CVE scan"
+      },
+      {
+        "context": "Docker build (all images)"
+      },
+      {
+        "context": "Validate compose files"
+      },
+      {
+        "context": "E2E (compose up + smoke)"
+      },
+      {
+        "context": "E2E UI (Playwright)"
+      },
+      {
+        "context": "Adversarial block-matrix (proxy + WAF)"
+      }
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,29 @@ The test suite covers:
 5. Run E2E tests if possible
 6. Open a PR with description of what and why
 
+### What blocks a merge
+
+`main` requires a pull request and 17 green checks. The list is not a
+convention — it is `.github/branch-protection.json`, applied to GitHub and
+checkable against it:
+
+```bash
+scripts/branch-protection.sh verify   # diff the live protection against the file
+scripts/branch-protection.sh apply    # push the file's state to GitHub (needs admin:repo)
+```
+
+Everything in that list is deterministic and derived from the code, so a red
+check means the PR broke something. Two checks run but deliberately do **not**
+gate: *Verify popular list URLs* reaches third-party hosts, where an upstream
+outage would block every unrelated merge, and the CodeQL *Analyze* jobs are
+GitHub-managed, where a change to the analysed language set would leave a
+required check pending forever. Their findings still surface — in the job log
+and in the Security tab.
+
+`strict` is on, so a PR must be up to date with `main` before it merges. If
+Dependabot churn makes that painful, that is the one setting to relax; the
+required-check list is not.
+
 ## Reporting Issues
 
 - Use [GitHub Issues](https://github.com/fabriziosalmi/secure-proxy-manager/issues)

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Branch protection for `main`, as a reviewed file instead of a memory of clicks.
+#
+# The protection on main used to be a shell: required_status_checks existed with
+# `strict: true` and an EMPTY context list, force pushes were allowed, and no
+# pull request was required. So "up to date with main" was enforced against
+# nothing, and a red CI never blocked a merge — the only thing standing between
+# a broken main and a merge was whoever was reading the check list.
+#
+# Keeping the desired state in .github/branch-protection.json means it can be
+# reviewed in a PR, diffed against reality, and restored after someone relaxes
+# it "just for a minute".
+#
+#   scripts/branch-protection.sh verify   # diff live state against the file (default)
+#   scripts/branch-protection.sh apply    # write the file's state to GitHub
+#
+# apply needs a token with `repo` admin scope: `gh auth refresh -s admin:repo`.
+set -uo pipefail
+
+REPO="${REPO:-fabriziosalmi/secure-proxy-manager}"
+BRANCH="${BRANCH:-main}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESIRED="$DIR/.github/branch-protection.json"
+API="repos/$REPO/branches/$BRANCH/protection"
+
+command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 2; }
+command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 2; }
+[ -f "$DESIRED" ] || { echo "missing $DESIRED" >&2; exit 2; }
+
+# normalize reduces a protection document — either the desired file or the
+# live API response, whose shape differs — to the same comparable form.
+normalize() {
+  python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+
+def flag(v):
+    # The API wraps booleans as {"enabled": bool}; the request body uses plain bools.
+    return v.get("enabled") if isinstance(v, dict) else bool(v)
+
+rsc = d.get("required_status_checks") or {}
+# The API returns both the modern "checks" list and the legacy "contexts";
+# compare on the names only.
+if rsc.get("checks"):
+    contexts = sorted(c["context"] for c in rsc["checks"])
+else:
+    contexts = sorted(rsc.get("contexts") or [])
+
+pr = d.get("required_pull_request_reviews")
+out = {
+    "pull_request_required": pr is not None,
+    "required_approving_review_count": (pr or {}).get("required_approving_review_count"),
+    "dismiss_stale_reviews": (pr or {}).get("dismiss_stale_reviews"),
+    "strict_up_to_date": rsc.get("strict"),
+    "required_checks": contexts,
+    "enforce_admins": flag(d.get("enforce_admins")),
+    "required_linear_history": flag(d.get("required_linear_history")),
+    "allow_force_pushes": flag(d.get("allow_force_pushes")),
+    "allow_deletions": flag(d.get("allow_deletions")),
+    "required_conversation_resolution": flag(d.get("required_conversation_resolution")),
+    "lock_branch": flag(d.get("lock_branch")),
+}
+json.dump(out, sys.stdout, indent=2, sort_keys=True)
+print()
+'
+}
+
+case "${1:-verify}" in
+  apply)
+    echo "applying $DESIRED to $REPO@$BRANCH ..."
+    gh api --method PUT "$API" --input "$DESIRED" >/dev/null || {
+      echo "PUT failed — the token needs admin scope: gh auth refresh -s admin:repo" >&2
+      exit 1
+    }
+    echo "applied. re-verifying:"
+    exec "$0" verify
+    ;;
+  verify)
+    live="$(gh api "$API" 2>/dev/null)" || {
+      echo "cannot read protection on $REPO@$BRANCH (needs admin scope, or none is set)" >&2
+      exit 1
+    }
+    a="$(printf '%s' "$live" | normalize)"
+    b="$(normalize < "$DESIRED")"
+    if [ "$a" = "$b" ]; then
+      echo "OK: branch protection on $REPO@$BRANCH matches .github/branch-protection.json"
+      printf '%s\n' "$b"
+      exit 0
+    fi
+    echo "DRIFT: live protection does not match .github/branch-protection.json"
+    diff -u <(printf '%s\n' "$b") <(printf '%s\n' "$a") | sed '1,2d'
+    echo
+    echo "run: scripts/branch-protection.sh apply"
+    exit 1
+    ;;
+  *)
+    echo "usage: $0 [verify|apply]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Branch protection on `main` was a shell: `required_status_checks` had `strict: true` with an **empty** context list, force pushes were allowed, and no pull request was required. "Up to date with main" was enforced against nothing, and a red CI could not block a merge.

This puts the desired state in `.github/branch-protection.json` — reviewable, diffable, restorable — and adds `scripts/branch-protection.sh` to check the live configuration against it.

**17 required checks.** Every name was verified against the check runs GitHub actually emitted for `e78d04e`, not read off the workflow YAML: a required check whose name does not match stays pending forever and blocks the branch permanently.

**Two jobs run but deliberately do not gate.** `Verify popular list URLs` reaches third-party hosts, where an upstream outage would block every unrelated merge. The CodeQL `Analyze` jobs are GitHub-managed default setup, where a change to the analysed language set would leave a required check with nothing to satisfy it. Both still report.

Applying is out-of-band and needs `admin:repo`:

```bash
scripts/branch-protection.sh verify   # shows the current drift
scripts/branch-protection.sh apply
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)