### PR TITLE
Record that the branch-protection API will not block force pushes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,11 @@ GitHub-managed, where a change to the analysed language set would leave a
 required check pending forever. Their findings still surface — in the job log
 and in the Security tab.
 
+`apply` restores everything except one field: GitHub's branch-protection API
+accepts `allow_force_pushes: false` and silently leaves it enabled. `verify`
+compares it, so the gap shows up as drift; fix that one under
+**Settings → Branches → main**.
+
 `strict` is on, so a PR must be up to date with `main` before it merges. If
 Dependabot churn makes that painful, that is the one setting to relax; the
 required-check list is not.

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -11,6 +11,17 @@
 # reviewed in a PR, diffed against reality, and restored after someone relaxes
 # it "just for a minute".
 #
+# ONE FIELD DOES NOT APPLY THROUGH THIS API. `allow_force_pushes: false` is
+# accepted, returns 200, and every other field in the same request lands — but
+# the setting stays `true`. Reproduced on repeated applies against this repo,
+# with no ruleset present to explain it; setting it in the web UI works.
+#
+# That matters most in the situation this script exists for: an `apply` run to
+# RESTORE protection after someone relaxed it will not restore force-push
+# blocking. `verify` compares the field precisely so the gap is visible rather
+# than assumed — if it ever reports drift on allow_force_pushes, fix it under
+# Settings -> Branches -> main, not by re-running apply.
+#
 #   scripts/branch-protection.sh verify   # diff live state against the file (default)
 #   scripts/branch-protection.sh apply    # write the file's state to GitHub
 #


### PR DESCRIPTION
`allow_force_pushes: false` is accepted by GitHub's branch-protection API, returns 200, and applies alongside every other field in the same request — and leaves the setting enabled. Reproduced across repeated applies against this repo, with no ruleset present to explain it. The web UI sets it correctly, and that is how it is now off; `verify` reports `OK` with zero drift.

Worth writing down because of *when* it bites: the situation `scripts/branch-protection.sh` exists for is restoring protection after someone relaxed it, and an `apply` in that moment silently leaves force pushes open on `main` — the one setting that can erase the history everything else in the gate protects.

No behaviour change. `verify` already compared the field; this documents what to do when it reports drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)