### PR TITLE
docs(seo): JSON-LD, llms.txt, security.txt, large image previews

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -41,6 +41,42 @@ export default defineConfig({
     ['meta', { name: 'twitter:card', content: 'summary' }],
     ['meta', { name: 'twitter:title', content: 'Secure Proxy Manager — Self-hosted Secure Web Gateway' }],
     ['meta', { name: 'twitter:description', content: OG_DESCRIPTION }],
+    // Let Google Discover use large image previews. This belongs in a <meta>,
+    // not in robots.txt: a *.github.io project page is a sub-path, and crawlers
+    // read robots.txt only from the domain root — which this repository does
+    // not own, so a directive placed there would never be read.
+    ['meta', { name: 'robots', content: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' }],
+    // Structured data for search engines and AI crawlers (Schema.org). WebSite
+    // describes the documentation site, SoftwareApplication the project it
+    // documents; emitted site-wide so any entry page carries it.
+    [
+      'script',
+      { type: 'application/ld+json' },
+      JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebSite',
+            name: 'Secure Proxy Manager',
+            url: `${SITE_URL}/`,
+            description: OG_DESCRIPTION,
+          },
+          {
+            '@type': 'SoftwareApplication',
+            name: 'Secure Proxy Manager',
+            description: OG_DESCRIPTION,
+            url: `${SITE_URL}/`,
+            applicationCategory: 'SecurityApplication',
+            operatingSystem: 'Linux, macOS',
+            programmingLanguage: ['Go', 'TypeScript'],
+            license: 'https://github.com/fabriziosalmi/secure-proxy-manager/blob/main/LICENSE',
+            codeRepository: 'https://github.com/fabriziosalmi/secure-proxy-manager',
+            author: { '@type': 'Person', name: 'Fabrizio Salmi' },
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+          },
+        ],
+      }),
+    ] as [string, Record<string, string>, string],
     // Everything this site loads is first-party. 'unsafe-inline' is required
     // because VitePress emits an inline appearance script and inline styles.
     // Applied to the built site only: `vitepress dev` serves HMR over a

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,13 @@
+# Secure Proxy Manager — vulnerability disclosure (RFC 9116)
+#
+# Note on location: RFC 9116 places this file at the DOMAIN root. This project
+# is served from a *.github.io project path, so the copy below lives at
+# /secure-proxy-manager/.well-known/security.txt and the authoritative
+# domain-root copy is owned by the fabriziosalmi.github.io apex repository.
+# Report to either; both reach the same person.
+Contact: https://github.com/fabriziosalmi/secure-proxy-manager/security/advisories/new
+Contact: mailto:fabrizio.salmi@gmail.com
+Policy: https://fabriziosalmi.github.io/secure-proxy-manager/guide/security
+Preferred-Languages: en, it
+Expires: 2027-09-09T00:00:00.000Z
+Canonical: https://fabriziosalmi.github.io/secure-proxy-manager/.well-known/security.txt

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,34 @@
+# Secure Proxy Manager
+
+> Self-hosted Secure Web Gateway: a Squid forward proxy, a real WAF speaking ICAP, a DNS sinkhole and a modern web UI, in one Docker Compose stack. It gives a network a single controllable egress point — the self-hosted counterpart to a cloud SWG, with no traffic leaving your network.
+
+Five containers: a React UI behind nginx, a Go backend (chi + SQLite in WAL mode), a Go WAF that Squid calls over ICAP for every request, Squid itself with optional SSL-bump, and dnsmasq as a sinkhole. The WAF carries 172 regex rules across 21 categories plus seven behavioural heuristics, screened by an Aho-Corasick pre-filter so benign traffic skips the rule set. Images are published multi-arch and signed with cosign.
+
+## Documentation
+
+- [What is Secure Proxy Manager?](https://fabriziosalmi.github.io/secure-proxy-manager/guide/introduction): what it does, who it is for, and what it is not
+- [Getting started](https://fabriziosalmi.github.io/secure-proxy-manager/guide/getting-started): from clone to a running stack
+- [Architecture](https://fabriziosalmi.github.io/secure-proxy-manager/guide/architecture): the five containers, the request path, and the /config contract between them
+
+## Configuration
+
+- [Environment variables](https://fabriziosalmi.github.io/secure-proxy-manager/guide/configuration): every variable, its default, and what breaks without it
+- [Blacklists and whitelists](https://fabriziosalmi.github.io/secure-proxy-manager/guide/blacklists): source and destination lists, imports, and the egress default-deny mode
+- [Security](https://fabriziosalmi.github.io/secure-proxy-manager/guide/security): the WAF, SSL-bump, authentication, and the hardening choices
+- [Security advisories](https://fabriziosalmi.github.io/secure-proxy-manager/guide/security-advisories): published advisories and the fixed versions
+
+## API
+
+- [API overview](https://fabriziosalmi.github.io/secure-proxy-manager/api/reference): conventions, pagination, and the X-API-Version contract
+- [Authentication](https://fabriziosalmi.github.io/secure-proxy-manager/api/authentication): JWT issue, refresh and revocation
+- [Blacklists and whitelists](https://fabriziosalmi.github.io/secure-proxy-manager/api/blacklists): list, add, import and geo-import endpoints
+- [Logs and analytics](https://fabriziosalmi.github.io/secure-proxy-manager/api/logs): access logs, filtering, and the analytics aggregates
+- [Settings and maintenance](https://fabriziosalmi.github.io/secure-proxy-manager/api/settings): bulk settings, config reload, backup and restore
+- [WebSocket](https://fabriziosalmi.github.io/secure-proxy-manager/api/websocket): the live event stream and its single-use token
+
+## Source
+
+- [GitHub repository](https://github.com/fabriziosalmi/secure-proxy-manager): source, issues and releases
+- [Changelog](https://github.com/fabriziosalmi/secure-proxy-manager/blob/main/CHANGELOG.md): release notes, with the breaking changes called out per release
+- [Deployment guide](https://github.com/fabriziosalmi/secure-proxy-manager/blob/main/DEPLOYMENT.md): install, upgrade, and key rotation
+- [Contributing](https://github.com/fabriziosalmi/secure-proxy-manager/blob/main/CONTRIBUTING.md): the local commands that reproduce each CI gate


### PR DESCRIPTION
Four of the ten findings from the site audit (#3 JSON-LD, #4 llms.txt, #5 security.txt, #9 max-image-preview). The other six were declined or were already satisfied.

## Two corrections to the audit

**security.txt was already there.** RFC 9116 places the file at the *domain root*, and this site is a `*.github.io` project sub-path — so the root is `fabriziosalmi.github.io`, owned by the apex repository, where a valid copy already answers 200 with a `Contact` and an `Expires` in 2027. The copy added here is a convenience under the project path and says so in its own header.

**`max-image-preview` does not belong in `robots.txt`.** Crawlers read `robots.txt` only from the domain root, which this repository does not own, so a directive placed in `docs/public/robots.txt` would never be read. It is a `<meta>` instead.

That second point has a consequence the audit did not raise: **the sitemap this project generates is not announced to crawlers**. `https://fabriziosalmi.github.io/robots.txt` — the only one that is read — currently lists the zion sitemap alone. Fixing that belongs in the apex repository, not here.

## Not done, on purpose

- `og:image` (3 pts) and `apple-touch-icon` — both need a 1200×630 / 180×180 raster; skipped by decision.
- `<title>` at 20 characters against a recommended 30–60 — left alone.
- Custom domain (1 pt) and the HSTS that would follow — `github.io` is the right home for this project.

## Verified

A local build was inspected rather than assumed: `dist` carries `llms.txt`, `.well-known/security.txt` and `sitemap.xml`; the emitted JSON-LD parses and holds both `WebSite` and `SoftwareApplication`; the robots meta is in the rendered HTML.

**To check after deploy:** the same file in the zion repository builds into `dist` but answers 404 in production, so a dot-directory may not survive publication. If it 404s here too, the fix belongs in the apex repository, where the canonical copy already lives.

## Still manual

GitHub Discussions is **already enabled** — the audit is wrong that it is not. What is missing is content: zero topics. That single item is 20 of the 29 recoverable points, and no commit can supply it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)