### PR TITLE
fix(waf): block a comment terminator in a request body (#266)

### DIFF
--- a/tests/adversarial/corpus.json
+++ b/tests/adversarial/corpus.json
@@ -55,6 +55,45 @@
     "desc": "comment terminator truncating the password check (SECURE-INPT-01)"
   },
   {
+    "id": "sqli-comment-body",
+    "category": "SQL_INJECTION",
+    "kind": "malicious",
+    "vector": "body",
+    "method": "POST",
+    "path": "/login",
+    "content_type": "application/x-www-form-urlencoded",
+    "body": "user=admin'--&pass=x",
+    "expect": "block",
+    "gate": "hard",
+    "desc": "comment terminator in a form body — a login form posts credentials, and there the %27 signal SQLi-018 used to lean on does not exist (#266)"
+  },
+  {
+    "id": "sqli-comment-hash-body",
+    "category": "SQL_INJECTION",
+    "kind": "malicious",
+    "vector": "body",
+    "method": "POST",
+    "path": "/login",
+    "content_type": "application/x-www-form-urlencoded",
+    "body": "user=admin'#&pass=x",
+    "expect": "block",
+    "gate": "hard",
+    "desc": "MySQL hash comment terminator in a form body (#266)"
+  },
+  {
+    "id": "benign-cli-flags-body",
+    "category": "SQL_INJECTION",
+    "kind": "benign",
+    "vector": "body",
+    "method": "POST",
+    "path": "/api/run",
+    "content_type": "application/json",
+    "body": "{\"args\":[\"--json\",\"--verbose\"],\"style\":\"--brand-color\"}",
+    "expect": "allow",
+    "gate": "hard",
+    "desc": "a quote OPENING a literal that starts with dashes — the shape the pre-#266 rule could not tell from an attack"
+  },
+  {
     "id": "benign-equality-prose",
     "category": "SQL_INJECTION",
     "kind": "benign",
@@ -313,7 +352,7 @@
     "path": "/p?u=%E2%80%8Badmin",
     "expect": "block",
     "gate": "soft",
-    "desc": "Zero-width space obfuscation (UNI-001) \u2014 soft: interacts with NFKC normalization"
+    "desc": "Zero-width space obfuscation (UNI-001) — soft: interacts with NFKC normalization"
   },
   {
     "id": "financial-single-card",
@@ -324,7 +363,7 @@
     "path": "/p?cc=4111111111111111",
     "expect": "pass",
     "gate": "soft",
-    "desc": "Single Visa PAN \u2014 sub-threshold by design (FIN-001 score 2 < 10), corroborating signal only"
+    "desc": "Single Visa PAN — sub-threshold by design (FIN-001 score 2 < 10), corroborating signal only"
   },
   {
     "id": "benign-index",

--- a/waf-go/internal/engine/rules.go
+++ b/waf-go/internal/engine/rules.go
@@ -76,12 +76,23 @@ var blockRules = []CategoryRules{
 			// URL-encoded-quote signal is absent and nothing else would
 			// corroborate it.
 			r("SQLi-017", `(?i)\b(?:OR|AND)\s+\(?\s*['"]?[\w.\-]{0,32}['"]?\s*=\s*['"]?[\w.\-]{0,32}['"]?`, 10, 2),
-			// SQLi-018: a quote immediately followed by a comment introducer,
-			// which truncates the rest of the statement — admin'-- defeats a
-			// password check without needing a tautology. Below the threshold on
-			// purpose: it pairs with SQLi-015 in a URL, and a lone '-- in prose
-			// should not block on its own.
-			r("SQLi-018", `(?i)['"]\s*(?:--|#)`, 6, 3),
+			// SQLi-018: a quote CLOSING a literal and immediately followed by a
+			// comment introducer, which truncates the rest of the statement —
+			// admin'-- defeats a password check without needing a tautology.
+			//
+			// The leading [\w)] is what makes this safe to score on its own. The
+			// rule used to be ['"]\s*(?:--|#) at severity 6, which also matches a
+			// quote OPENING a literal that happens to start with dashes or a
+			// hash: {"args":["--json"]}, "--custom-brand-color", "# heading".
+			// Six of eight benign JSON/CSS samples matched it, which is why it
+			// could not block alone — and that left a real gap. In a URL it
+			// paired with SQLi-015 (the %27 on the raw URL) to reach 10, but a
+			// login form submits credentials in a BODY, where no percent-encoded
+			// quote exists: admin'-- scored 6 there and passed. Requiring a word
+			// character or a closing paren before the quote distinguishes the
+			// end of a quoted literal from the start of one, and drops those
+			// false positives to zero, so the rule can carry the block itself.
+			r("SQLi-018", `(?i)[\w)]\s*['"]\s*\)?\s*(?:--|#)`, 10, 2),
 		},
 	},
 

--- a/waf-go/reqmod_characterization_test.go
+++ b/waf-go/reqmod_characterization_test.go
@@ -129,7 +129,37 @@ func TestHandleReqmodVerdicts(t *testing.T) {
 				return httptest.NewRequest("GET", "http://example.com/login?user=admin%27--&pass=x", nil)
 			},
 			clientIP: "198.51.100.21",
-			want:     verdict{ICAPCode: 200, HTTPStatus: 403, Action: "block", Score: 10, Rules: "SQLi-015,SQLi-018", FeatureFound: true},
+			// SQLi-018 carries this alone now. It used to need SQLi-015 — the
+			// %27 on the raw URL — to reach the threshold, which is exactly why
+			// the same payload passed in a request body, where no percent-
+			// encoded quote exists (#266).
+			want: verdict{ICAPCode: 200, HTTPStatus: 403, Action: "block", Score: 10, Rules: "SQLi-018", FeatureFound: true},
+		},
+		{
+			// The gap #266 left open: a login form submits credentials in a
+			// body, and there the URL-encoded-quote signal is absent.
+			name: "comment-terminator in a form body blocks",
+			request: func() *http.Request {
+				r := httptest.NewRequest("POST", "http://example.com/login-body",
+					strings.NewReader("user=admin'--&pass=x"))
+				r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return r
+			},
+			clientIP: "198.51.100.22",
+			want:     verdict{ICAPCode: 200, HTTPStatus: 403, Action: "block", Score: 10, Rules: "SQLi-018", FeatureFound: true},
+		},
+		{
+			// The shape the old rule could not tell apart from an attack: a
+			// quote OPENING a literal that starts with dashes. Must not block.
+			name: "a JSON body carrying CLI-style flags is allowed",
+			request: func() *http.Request {
+				r := httptest.NewRequest("POST", "http://example.com/api/run",
+					strings.NewReader(`{"args":["--json","--verbose"],"style":"--brand-color"}`))
+				r.Header.Set("Content-Type", "application/json")
+				return r
+			},
+			clientIP: "198.51.100.23",
+			want:     verdict{ICAPCode: 204, Action: "allow", Score: 0, Rules: "", FeatureFound: true},
 		},
 		{
 			name: "quoted equality in prose is allowed",


### PR DESCRIPTION
Closes #266.

## The gap

`admin'--` is one of the most canonical authentication bypasses — it truncates the statement and defeats the password check without needing a tautology. It blocked in a URL and **passed in a request body**, which is where a login form actually sends credentials.

Measured through the full REQMOD pipeline, not just rule matching:

| payload | in a URL | in a form body |
|---|---|---|
| `admin'--` | block, 10 (SQLi-015 + SQLi-018) | **allow, 6** |
| `admin'#` | block, 10 | **allow, 6** |
| `admin' OR '1'='1` | block, 10 (SQLi-017) | block, 10 |

SQLi-018 scored 6 and leaned on SQLi-015 — the `%27` on the raw URL — to reach the threshold. A body has no percent-encoded quote to lean on.

## Why not just raise the severity

The old pattern `['"]\s*(?:--|#)` also matches a quote *opening* a literal that starts with dashes or a hash. Six of eight benign JSON/CSS samples matched it:

```
{"args":["--json","--verbose"]}    "--brand-color"    "# heading"    ["--", "stdin"]
```

That is precisely why it could not block alone. Scoring it 10 as written would have turned a coverage gap into a false-positive generator.

## The change

```
-  r("SQLi-018", `(?i)['"]\s*(?:--|#)`, 6, 3)
+  r("SQLi-018", `(?i)[\w)]\s*['"]\s*\)?\s*(?:--|#)`, 10, 2)
```

Requiring a word character or a closing paren before the quote separates the **end** of a quoted literal from the **start** of one. On the same samples: zero false positives, seven attack shapes matched including `user')--` and `x'-- -`.

## Verification

- Adversarial block-matrix **41/41, FN=0, FP=0** across 22 categories; all five planes pass.
- Three cases added to the corpus — the two body payloads that used to pass, and the JSON-with-CLI-flags shape the old rule could not distinguish from an attack. The gap was invisible before precisely because the corpus did not contain it.
- The WAF's own false-positive fuzzing passes unchanged.
- `go test -race ./...` clean, golangci-lint 0 issues.

## One deliberate behaviour change

The characterization suite flagged it: the URL case still blocks at 10, but the attributed rules are now `SQLi-018` alone rather than `SQLi-015,SQLi-018`. That is the fix working — the rule carries the block itself — so the expectation is updated and records why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)